### PR TITLE
fix FFI schema mismatch when there are fields with same names in record batches

### DIFF
--- a/native-engine/blaze/src/lib.rs
+++ b/native-engine/blaze/src/lib.rs
@@ -1,3 +1,4 @@
+use datafusion::arrow::datatypes::Schema;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -24,6 +25,7 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 pub struct BlazeIter {
     pub stream: SendableRecordBatchStream,
     pub execution_plan: Arc<dyn ExecutionPlan>,
+    pub renamed_schema: Arc<Schema>,
 }
 
 pub fn tokio_runtime(thread_num: usize) -> &'static Runtime {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/FFIHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/FFIHelper.scala
@@ -66,7 +66,10 @@ object FFIHelper {
         val arrayPtr: Long = consumerArray.memoryAddress
         val rt = JniBridge.loadNext(iterPtr, schemaPtr, arrayPtr)
         if (rt < 0) {
-          return Iterator.empty
+          return CompletionIterator[InternalRow, Iterator[InternalRow]](
+            Iterator.empty, {
+              allocator.close()
+            })
         }
         val root: VectorSchemaRoot =
           Data.importVectorSchemaRoot(allocator, consumerArray, consumerSchema, provider)


### PR DESCRIPTION
fix FFI schema mismatch when there are fields with same names in record batches
avoid memory leaking when returning an empty iterator