### PR TITLE
fix ReuseExchange + NativeUnion problem

### DIFF
--- a/native-engine/datafusion-ext/src/empty_partitions_exec.rs
+++ b/native-engine/datafusion-ext/src/empty_partitions_exec.rs
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::DataFusionError;
+use datafusion::error::Result;
+use datafusion::execution::context::TaskContext;
+
+use datafusion::physical_expr::PhysicalSortExpr;
+
+use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::Partitioning::UnknownPartitioning;
+use datafusion::physical_plan::{
+    DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
+    SendableRecordBatchStream, Statistics,
+};
+use futures::Stream;
+use std::any::Any;
+use std::fmt::Formatter;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+#[derive(Debug, Clone)]
+pub struct EmptyPartitionsExec {
+    schema: SchemaRef,
+    num_partitions: usize,
+}
+
+impl EmptyPartitionsExec {
+    pub fn new(schema: SchemaRef, num_partitions: usize) -> Self {
+        Self {
+            schema,
+            num_partitions,
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for EmptyPartitionsExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        UnknownPartitioning(self.num_partitions)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Plan(
+                "EmptyPartitionsExec expects no children".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        Ok(Box::pin(EmptyStream(self.schema.clone())))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
+    }
+
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(
+                    f,
+                    "EmptyPartitionsExec: partitions={}, schema={:?}",
+                    &self.num_partitions, &self.schema
+                )
+            }
+        }
+    }
+
+    fn statistics(&self) -> Statistics {
+        todo!()
+    }
+}
+
+struct EmptyStream(SchemaRef);
+
+impl RecordBatchStream for EmptyStream {
+    fn schema(&self) -> SchemaRef {
+        self.0.clone()
+    }
+}
+
+impl Stream for EmptyStream {
+    type Item = datafusion::arrow::error::Result<RecordBatch>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        Poll::Ready(None)
+    }
+}

--- a/native-engine/datafusion-ext/src/jni_bridge.rs
+++ b/native-engine/datafusion-ext/src/jni_bridge.rs
@@ -145,6 +145,7 @@ pub struct JavaClasses<'a> {
 
     pub cScalaIterator: ScalaIterator<'a>,
     pub cScalaTuple2: ScalaTuple2<'a>,
+    pub cScalaFunction0: ScalaFunction0<'a>,
 
     pub cHadoopFileSystem: HadoopFileSystem<'a>,
     pub cHadoopPath: HadoopPath<'a>,
@@ -193,6 +194,7 @@ impl JavaClasses<'static> {
 
             cScalaIterator: ScalaIterator::new(env)?,
             cScalaTuple2: ScalaTuple2::new(env)?,
+            cScalaFunction0: ScalaFunction0::new(env)?,
 
             cHadoopFileSystem: HadoopFileSystem::new(env)?,
             cHadoopPath: HadoopPath::new(env)?,
@@ -539,6 +541,25 @@ impl<'a> ScalaTuple2<'a> {
             method__1_ret: JavaType::Object("java/lang/Object".to_owned()),
             method__2: env.get_method_id(class, "_2", "()Ljava/lang/Object;")?,
             method__2_ret: JavaType::Object("java/lang/Object".to_owned()),
+        })
+    }
+}
+
+#[allow(non_snake_case)]
+pub struct ScalaFunction0<'a> {
+    pub class: JClass<'a>,
+    pub method_apply: JMethodID<'a>,
+    pub method_apply_ret: JavaType,
+}
+impl<'a> ScalaFunction0<'a> {
+    pub const SIG_TYPE: &'static str = "scala/Function0";
+
+    pub fn new(env: &JNIEnv<'a>) -> JniResult<ScalaFunction0<'a>> {
+        let class = get_global_jclass(env, Self::SIG_TYPE)?;
+        Ok(ScalaFunction0 {
+            class,
+            method_apply: env.get_method_id(class, "apply", "()Ljava/lang/Object;")?,
+            method_apply_ret: JavaType::Object("java/lang/Object".to_owned()),
         })
     }
 }

--- a/native-engine/datafusion-ext/src/lib.rs
+++ b/native-engine/datafusion-ext/src/lib.rs
@@ -5,6 +5,7 @@ use datafusion::datasource::object_store_registry::ObjectStoreRegistry;
 
 use hdfs_object_store::HDFSSingleFileObjectStore;
 
+pub mod empty_partitions_exec;
 pub mod hdfs_object_store; // note: can be changed to priv once plan transforming is removed
 pub mod jni_bridge;
 pub mod rename_columns_exec;

--- a/native-engine/datafusion-ext/src/shuffle_reader_exec.rs
+++ b/native-engine/datafusion-ext/src/shuffle_reader_exec.rs
@@ -117,12 +117,15 @@ impl ExecutionPlan for ShuffleReaderExec {
 
         let segments = Util::to_datafusion_external_result(Ok(()).and_then(|_| {
             let env = JavaClasses::get_thread_jnienv();
-            let segments = jni_bridge_call_static_method!(
+            let segments_provider = jni_bridge_call_static_method!(
                 env,
                 JniBridge.getResource,
                 env.new_string(&self.native_shuffle_id)?
             )?
             .l()?;
+            let segments =
+                jni_bridge_call_method!(env, ScalaFunction0.apply, segments_provider)?
+                    .l()?;
             JniResult::Ok(env.new_global_ref(segments)?)
         }))?;
         let schema = self.schema.clone();

--- a/native-engine/plan-serde/proto/plan.proto
+++ b/native-engine/plan-serde/proto/plan.proto
@@ -49,6 +49,7 @@ message PhysicalPlanNode {
     UnionExecNode union = 21;
     SortMergeJoinExecNode sort_merge_join = 22;
     RenameColumnsExecNode rename_columns = 23;
+    EmptyPartitionsExecNode empty_partitions = 24;
   }
 }
 
@@ -360,6 +361,11 @@ message SortMergeJoinExecNode {
 message RenameColumnsExecNode {
   PhysicalPlanNode input = 1;
   repeated string renamed_column_names = 2;
+}
+
+message EmptyPartitionsExecNode {
+  Schema schema = 1;
+  uint32 num_partitions = 2;
 }
 
 enum JoinType {

--- a/native-engine/plan-serde/src/lib.rs
+++ b/native-engine/plan-serde/src/lib.rs
@@ -613,7 +613,6 @@ impl TryFrom<&datafusion::scalar::ScalarValue> for protobuf::ScalarValue {
                 })
             }
             scalar::ScalarValue::List(value, datatype) => {
-                println!("Current datatype of list: {:?}", datatype);
                 match value {
                     Some(values) => {
                         if values.is_empty() {
@@ -630,7 +629,6 @@ impl TryFrom<&datafusion::scalar::ScalarValue> for protobuf::ScalarValue {
                                 DataType::List(field) => field.as_ref().data_type(),
                                 _ => todo!("Proper error handling"),
                             };
-                            println!("Current scalar type for list: {:?}", scalar_type);
                             let type_checked_values: Vec<protobuf::ScalarValue> = values
                                 .iter()
                                 .map(|scalar| match (scalar, scalar_type) {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeSparkSessionExtension.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeSparkSessionExtension.scala
@@ -338,7 +338,7 @@ case class BlazeQueryStagePrepOverrides(sparkSession: SparkSession)
       case exec: ShuffleQueryStageExec => needRenameColumns(exec.plan)
       case exec: BroadcastQueryStageExec => needRenameColumns(exec.plan)
       case exec: CustomShuffleReaderExec => needRenameColumns(exec.child)
-      case _: NativeParquetScanExec | _: ReusedExchangeExec => true
+      case _: NativeParquetScanExec | _: NativeUnionExec | _: ReusedExchangeExec => true
       case _ => false
     }
   }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowBlockStoreShuffleReader301.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowBlockStoreShuffleReader301.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark.sql.blaze.execution
 
+import java.nio.channels.SeekableByteChannel
+
+import scala.Function.tupled
+
 import org.apache.spark.InterruptibleIterator
 import org.apache.spark.MapOutputTracker
 import org.apache.spark.SparkEnv
@@ -37,7 +41,7 @@ import org.apache.spark.util.CompletionIterator
 
 class ArrowBlockStoreShuffleReader301[K, C](
     handle: BaseShuffleHandle[K, _, C],
-    blocksByAddress: Iterator[(BlockManagerId, Seq[(BlockId, Long, Int)])],
+    blocksByAddress: () => Iterator[(BlockManagerId, Seq[(BlockId, Long, Int)])],
     context: TaskContext,
     readMetrics: ShuffleReadMetricsReporter,
     serializerManager: SerializerManager = SparkEnv.get.serializerManager,
@@ -52,33 +56,35 @@ class ArrowBlockStoreShuffleReader301[K, C](
 
   /** Read the combined key-values for this reduce task */
   override def read(): Iterator[Product2[K, C]] = {
-    val buffers = new ShuffleBlockFetcherIterator301(
-      context,
-      blockManager.blockStoreClient,
-      blockManager,
-      blocksByAddress,
-      // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
-      SparkEnv.get.conf.get(config.REDUCER_MAX_SIZE_IN_FLIGHT) * 1024 * 1024,
-      SparkEnv.get.conf.get(config.REDUCER_MAX_REQS_IN_FLIGHT),
-      SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
-      SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
-      SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
-      SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
-      readMetrics,
-      fetchContinuousBlocksInBatch).toCompletionIterator
+    val provideBuffers = () =>
+      new ShuffleBlockFetcherIterator301(
+        context,
+        SparkEnv.get.blockManager.blockStoreClient,
+        SparkEnv.get.blockManager,
+        blocksByAddress(),
+        // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
+        SparkEnv.get.conf.get(config.REDUCER_MAX_SIZE_IN_FLIGHT) * 1024 * 1024,
+        SparkEnv.get.conf.get(config.REDUCER_MAX_REQS_IN_FLIGHT),
+        SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
+        SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
+        SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
+        SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
+        readMetrics,
+        fetchContinuousBlocksInBatch).toCompletionIterator
 
     // Store buffers in JniBridge
-    JniBridge.resourcesMap.put(
-      ArrowShuffleExchangeExec301.getNativeShuffleId(context, handle.shuffleId),
-      new InterruptibleIterator(
-        context,
-        buffers.flatMap {
-          case (blockId, managedBuffer) =>
-            Converters.readManagedBufferToSegmentByteChannels(managedBuffer).toIterator
-        }))
+    val resourceId = ArrowShuffleExchangeExec301.getNativeShuffleId(context, handle.shuffleId)
+    val provideIpcReader = () => {
+      val ipcIterator = provideBuffers().flatMap {
+        case (_, managedBuffer) =>
+          Converters.readManagedBufferToSegmentByteChannels(managedBuffer).toIterator
+      }
+      new InterruptibleIterator(context, ipcIterator)
+    }
+    JniBridge.resourcesMap.put(resourceId, () => provideIpcReader())
 
     // Create a key/value iterator for each stream
-    val recordIter = buffers.flatMap {
+    val recordIter = provideBuffers().flatMap {
       case (blockId, managedBuffer) =>
         // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
         // NextIterator. The NextIterator makes sure that close() is called on the

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowShuffleExchangeExec301.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowShuffleExchangeExec301.scala
@@ -188,6 +188,8 @@ case class ArrowShuffleExchangeExec301(
       rdd.dependencies,
       (partition, taskContext) => {
         // store fetch iterator in jni resource before native compute
+        logWarning(
+          s"FUCK NativeShuffleReader: stageId=${taskContext.stageId()}, partId: ${partition.index}")
         rdd.compute(rdd.partitions(partition.index), taskContext)
 
         PhysicalPlanNode

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowShuffleManager301.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowShuffleManager301.scala
@@ -138,8 +138,9 @@ class ArrowShuffleManager301(conf: SparkConf) extends ShuffleManager with Loggin
       endPartition: Int,
       context: TaskContext,
       metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    val blocksByAddress = SparkEnv.get.mapOutputTracker
-      .getMapSizesByExecutorId(handle.shuffleId, startPartition, endPartition)
+    val blocksByAddress = () =>
+      SparkEnv.get.mapOutputTracker
+        .getMapSizesByExecutorId(handle.shuffleId, startPartition, endPartition)
     new ArrowBlockStoreShuffleReader301(
       handle.asInstanceOf[BaseShuffleHandle[K, _, C]],
       blocksByAddress,
@@ -156,12 +157,13 @@ class ArrowShuffleManager301(conf: SparkConf) extends ShuffleManager with Loggin
       endPartition: Int,
       context: TaskContext,
       metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByRange(
-      handle.shuffleId,
-      startMapIndex,
-      endMapIndex,
-      startPartition,
-      endPartition)
+    val blocksByAddress = () =>
+      SparkEnv.get.mapOutputTracker.getMapSizesByRange(
+        handle.shuffleId,
+        startMapIndex,
+        endMapIndex,
+        startPartition,
+        endPartition)
     new ArrowBlockStoreShuffleReader301(
       handle.asInstanceOf[BaseShuffleHandle[K, _, C]],
       blocksByAddress,

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowWriterIterator.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/execution/ArrowWriterIterator.scala
@@ -68,7 +68,6 @@ class ArrowWriterIterator(
         writer.close()
       }
     }
-    System.err.println(s"outputStream.size=${outputStream.size()}")
     new NioSeekableByteChannel(outputStream.toByteBuffer, 0, outputStream.size())
   }
 }


### PR DESCRIPTION
    NativeUnion: use EmptyPartitionsExec to avoid executing children plans which are not part of current task

    fix ReuseExchange + NativeUnion problem

clean redundant printlns