### PR TITLE
Bump protoc version to 3.19.1

### DIFF
--- a/spark-extension/build.gradle
+++ b/spark-extension/build.gradle
@@ -182,7 +182,7 @@ protobuf {
 	// Configure the protoc executable
 	protoc {
 		// Download from repositories
-		artifact = 'com.google.protobuf:protoc:3.0.0'
+		artifact = 'com.google.protobuf:protoc:3.19.1'
 	}
 
 	generatedFilesBaseDir = "$projectDir/src/generated-sources"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #172.

 # Rationale for this change

This change allows buidling in linux-aarch64, which can happen if building from osx-aarch64 inside Docker


# What changes are included in this PR?

Bumped the protoc dependency in build.gradle

# Are there any user-facing changes?

No
