### PR TITLE
remove unused val in BlazeSparkSessionExtension

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeSparkSessionExtension.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeSparkSessionExtension.scala
@@ -50,10 +50,6 @@ object BlazeSparkSessionExtension extends Logging {
     .booleanConf
     .createWithDefault(true)
 
-  lazy val blazeMissPatterns: OptionalConfigEntry[String] = SQLConf
-    .buildConf("spark.blaze.blazeMissPatterns")
-    .stringConf
-    .createOptional
 
   def dumpSimpleSparkPlanTreeNode(exec: SparkPlan, depth: Int = 0): Unit = {
     val nodeName = exec.nodeName


### PR DESCRIPTION
Now we don't need a rules engine to control some SQL queries which won't be using Blaze engine as a whole and route them to Spark engine, so we don't need to maintain the delayed loading of blazeMissPatterns variable.