### PR TITLE
Fix spark333 scala version to 2.12.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <shimName>spark333</shimName>
         <javaVersion>1.8</javaVersion>
         <scalaVersion>2.12</scalaVersion>
-        <scalaLongVersion>2.12.10</scalaLongVersion>
+        <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.3.3</sparkVersion>


### PR DESCRIPTION
The Scala version for Spark 3.3.3 is 2.12.15. The version numbers must be consistent, otherwise, there will be compatibility issues and the executor may fail to start, resulting in an error.

https://github.com/apache/spark/blob/8c2b3319c6734250ff9d72f3d7e5cab56b142195/pom.xml#L161

```
23/10/23 20:05:07 WARN [rpc-client-1-1] TransportChannelHandler: Exception in connection from master-1-1/192.168.80.191:44635
java.io.InvalidClassException: scala.collection.mutable.WrappedArray$ofRef; local class incompatible: stream classdesc serialVersionUID = 3456489343829468865, local class serialVersionUID = 1028182004549731694
	at java.io.ObjectStreamClass.initNonProxy(ObjectStreamClass.java:699) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:2004) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1851) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1668) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2430) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2354) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2212) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1668) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:502) ~[?:1.8.0_372]
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:460) ~[?:1.8.0_372]
```