### PR TITLE
upgrade datafusion: fix parquet pruning with NaN values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=38077432e#38077432e66bab447b7aa138b9be9608f252e9c2"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
 dependencies = [
  "ahash",
  "arrow",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=38077432e#38077432e66bab447b7aa138b9be9608f252e9c2"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=38077432e#38077432e66bab447b7aa138b9be9608f252e9c2"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
 dependencies = [
  "arrow",
  "dashmap",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=38077432e#38077432e66bab447b7aa138b9be9608f252e9c2"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
 dependencies = [
  "ahash",
  "arrow",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=38077432e#38077432e66bab447b7aa138b9be9608f252e9c2"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=38077432e#38077432e66bab447b7aa138b9be9608f252e9c2"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
 dependencies = [
  "ahash",
  "arrow",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=38077432e#38077432e66bab447b7aa138b9be9608f252e9c2"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,12 @@ serde_json = { version = "1.0.96" }
 
 [patch.crates-io]
 # datafusion: branch=v30-blaze
-datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "38077432e"}
-datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "38077432e"}
-datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "38077432e"}
-datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "38077432e"}
-datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "38077432e"}
-datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "38077432e"}
+datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
+datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
+datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
+datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
+datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
+datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
 
 # arrow: branch=v45-blaze
 arrow = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}


### PR DESCRIPTION
when a parquet floating column contains NaNs in its statistics. datafusion will unexpectedly prune some row groups.
this is fixed in [d773c00](https://github.com/blaze-init/arrow-datafusion/commit/d773c004e379a482fc710773389780d39e6f0c71)