### PR TITLE
use RecordBatch::try_new_with_options in most situation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "arrow"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "ahash",
  "arrow-arith",
@@ -117,7 +117,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -131,7 +131,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "half",
  "num",
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -249,7 +249,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "bitflags 2.4.0",
  "serde",
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=bb659b6ee#bb659b6ee612613a122b41f37e4986e616fccbe9"
 dependencies = [
  "ahash",
  "arrow",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=bb659b6ee#bb659b6ee612613a122b41f37e4986e616fccbe9"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=bb659b6ee#bb659b6ee612613a122b41f37e4986e616fccbe9"
 dependencies = [
  "arrow",
  "dashmap",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=bb659b6ee#bb659b6ee612613a122b41f37e4986e616fccbe9"
 dependencies = [
  "ahash",
  "arrow",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=bb659b6ee#bb659b6ee612613a122b41f37e4986e616fccbe9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=bb659b6ee#bb659b6ee612613a122b41f37e4986e616fccbe9"
 dependencies = [
  "ahash",
  "arrow",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "30.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=054f2a111#054f2a111ec9461f283c0838f2120da2b9330f0a"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=bb659b6ee#bb659b6ee612613a122b41f37e4986e616fccbe9"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1815,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "45.0.0"
-source = "git+https://github.com/blaze-init/arrow-rs.git?rev=5a6d98d183#5a6d98d1832d9a0169e291db0a0ba0a88045e701"
+source = "git+https://github.com/blaze-init/arrow-rs.git?rev=7706029cfa#7706029cfa5a130e0285bfe489c23f94c0d0635c"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,26 +64,26 @@ serde_json = { version = "1.0.96" }
 
 [patch.crates-io]
 # datafusion: branch=v30-blaze
-datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
-datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
-datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
-datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
-datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
-datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "054f2a111"}
+datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "bb659b6ee"}
+datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "bb659b6ee"}
+datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "bb659b6ee"}
+datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "bb659b6ee"}
+datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "bb659b6ee"}
+datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "bb659b6ee"}
 
 # arrow: branch=v45-blaze
-arrow = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-arith = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-array = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-buffer = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-cast = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-data = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-ord = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-row = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-schema = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-select = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-arrow-string = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
-parquet = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "5a6d98d183"}
+arrow = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-arith = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-array = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-buffer = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-cast = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-data = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-ord = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-row = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-schema = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-select = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+arrow-string = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
+parquet = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "7706029cfa"}
 
 # serde_json: branch=v1.0.96-blaze
 serde_json = { git = "https://github.com/blaze-init/json", branch = "v1.0.96-blaze" }

--- a/native-engine/datafusion-ext-commons/src/lib.rs
+++ b/native-engine/datafusion-ext-commons/src/lib.rs
@@ -16,14 +16,6 @@
 #![feature(io_error_other)]
 #![feature(slice_swap_unchecked)]
 
-use arrow::{
-    compute::concat,
-    datatypes::SchemaRef,
-    error::Result as ArrowResult,
-    record_batch::{RecordBatch, RecordBatchOptions},
-};
-use log::trace;
-
 pub mod array_builder;
 pub mod bytes_arena;
 pub mod cast;
@@ -35,33 +27,3 @@ pub mod slim_bytes;
 pub mod spark_hash;
 pub mod streams;
 pub mod uda;
-
-/// Concatenates an array of `RecordBatch` into one batch
-pub fn concat_batches(
-    schema: &SchemaRef,
-    batches: &[RecordBatch],
-    row_count: usize,
-) -> ArrowResult<RecordBatch> {
-    if batches.is_empty() {
-        return Ok(RecordBatch::new_empty(schema.clone()));
-    }
-    let mut arrays = Vec::with_capacity(schema.fields().len());
-    for i in 0..schema.fields().len() {
-        let array = concat(
-            &batches
-                .iter()
-                .map(|batch| batch.column(i).as_ref())
-                .collect::<Vec<_>>(),
-        )?;
-        arrays.push(array);
-    }
-    trace!(
-        "Combined {} batches containing {} rows",
-        batches.len(),
-        row_count
-    );
-
-    let options = RecordBatchOptions::new().with_row_count(Some(row_count));
-
-    RecordBatch::try_new_with_options(schema.clone(), arrays, &options)
-}

--- a/native-engine/datafusion-ext-commons/src/spark_hash.rs
+++ b/native-engine/datafusion-ext-commons/src/spark_hash.rs
@@ -154,24 +154,6 @@ macro_rules! hash_array_decimal {
     };
 }
 
-macro_rules! hash_list_decimal {
-    ($array_type:ident, $column:ident, $hash:ident) => {
-        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
-
-        if array.null_count() == 0 {
-            for i in 0..array.len() {
-                *$hash = spark_compatible_murmur3_hash(array.value(i).to_le_bytes(), *$hash);
-            }
-        } else {
-            for i in 0..array.len() {
-                if !array.is_null(i) {
-                    *$hash = spark_compatible_murmur3_hash(array.value(i).to_le_bytes(), *$hash);
-                }
-            }
-        }
-    };
-}
-
 /// Hash the values in a dictionary array
 fn create_hashes_dictionary<K: ArrowDictionaryKeyType>(
     array: &ArrayRef,

--- a/native-engine/datafusion-ext-commons/src/streams/coalesce_stream.rs
+++ b/native-engine/datafusion-ext-commons/src/streams/coalesce_stream.rs
@@ -23,13 +23,12 @@ use datafusion::{
     common::Result,
     execution::TaskContext,
     physical_plan::{
+        coalesce_batches::concat_batches,
         metrics::{BaselineMetrics, Time},
         RecordBatchStream, SendableRecordBatchStream,
     },
 };
 use futures::{Stream, StreamExt};
-
-use crate::concat_batches;
 
 const STAGING_BATCHES_MEM_SIZE_LIMIT: usize = 1 << 26; // limit output batch size to 64MB
 

--- a/native-engine/datafusion-ext-plans/src/expand_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/expand_exec.rs
@@ -12,27 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    any::Any,
-    fmt::Formatter,
-    pin::Pin,
-    sync::Arc,
-    task::{ready, Context, Poll},
-};
+use std::{any::Any, fmt::Formatter, sync::Arc};
 
-use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use arrow::{
+    datatypes::SchemaRef,
+    record_batch::{RecordBatch, RecordBatchOptions},
+};
 use datafusion::{
     common::{DataFusionError, Result, Statistics},
     execution::context::TaskContext,
     physical_expr::{PhysicalExpr, PhysicalSortExpr},
     physical_plan::{
         metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet},
+        stream::RecordBatchStreamAdapter,
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
         Partitioning::UnknownPartitioning,
-        RecordBatchStream, SendableRecordBatchStream,
+        SendableRecordBatchStream,
     },
 };
-use futures::{Stream, StreamExt};
+use datafusion_ext_commons::cast::cast;
+use futures::{stream::once, StreamExt, TryStreamExt};
+
+use crate::common::output::TaskOutputter;
 
 #[derive(Debug, Clone)]
 pub struct ExpandExec {
@@ -124,16 +125,18 @@ impl ExecutionPlan for ExpandExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
-        let input = self.input.execute(partition, context)?;
-
-        Ok(Box::pin(ExpandStream {
-            schema: self.schema(),
-            projections: self.projections.clone(),
+        let input = self.input.execute(partition, context.clone())?;
+        let stream = execute_expand(
+            context,
             input,
-            metrics: Arc::new(baseline_metrics),
-            current_batch: None,
-            current_projection_id: 0,
-        }))
+            self.projections.clone(),
+            self.schema(),
+            baseline_metrics,
+        );
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            once(stream).try_flatten(),
+        )))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -145,55 +148,41 @@ impl ExecutionPlan for ExpandExec {
     }
 }
 
-struct ExpandStream {
-    schema: SchemaRef,
+async fn execute_expand(
+    context: Arc<TaskContext>,
+    mut input: SendableRecordBatchStream,
     projections: Vec<Vec<Arc<dyn PhysicalExpr>>>,
-    input: SendableRecordBatchStream,
-    metrics: Arc<BaselineMetrics>,
-    current_batch: Option<RecordBatch>,
-    current_projection_id: usize,
-}
+    output_schema: SchemaRef,
+    metrics: BaselineMetrics,
+) -> Result<SendableRecordBatchStream> {
+    context.output_with_sender("Expand", output_schema.clone(), move |sender| async move {
+        while let Some(batch) = input.next().await.transpose()? {
+            let mut timer = metrics.elapsed_compute().timer();
+            let num_rows = batch.num_rows();
 
-impl RecordBatchStream for ExpandStream {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-}
-
-impl Stream for ExpandStream {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // continue processing current batch
-        if let Some(batch) = &self.current_batch {
-            let _timer = self.metrics.elapsed_compute();
-            let projections = &self.projections[self.current_projection_id];
-            let arrays = projections
-                .iter()
-                .map(|expr| expr.evaluate(batch))
-                .map(|r| r.map(|v| v.into_array(batch.num_rows())))
-                .collect::<Result<Vec<_>>>()?;
-            let output_batch = RecordBatch::try_new(self.schema.clone(), arrays)?;
-
-            self.current_projection_id += 1;
-            if self.current_projection_id >= self.projections.len() {
-                self.current_batch = None;
-                self.current_projection_id = 0;
-            }
-            return self
-                .metrics
-                .record_poll(Poll::Ready(Some(Ok(output_batch))));
-        }
-
-        // current batch has been consumed, poll next batch
-        match ready!(self.input.poll_next_unpin(cx)).transpose()? {
-            None => Poll::Ready(None),
-            Some(batch) => {
-                self.current_batch = Some(batch);
-                self.poll_next(cx)
+            for projection in &projections {
+                let arrays = projection
+                    .iter()
+                    .zip(output_schema.fields())
+                    .map(|(expr, field)| {
+                        let array = expr.evaluate(&batch).map(|c| c.into_array(num_rows))?;
+                        if array.data_type() != field.data_type() {
+                            return cast(&array, field.data_type());
+                        }
+                        Ok(array)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let output_batch = RecordBatch::try_new_with_options(
+                    output_schema.clone(),
+                    arrays,
+                    &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+                )?;
+                metrics.record_output(output_batch.num_rows());
+                sender.send(Ok(output_batch), Some(&mut timer)).await;
             }
         }
-    }
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/native-engine/datafusion-ext-plans/src/parquet_sink_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/parquet_sink_exec.rs
@@ -17,7 +17,10 @@
 
 use std::{any::Any, fmt::Formatter, io::Write, sync::Arc};
 
-use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use arrow::{
+    datatypes::SchemaRef,
+    record_batch::{RecordBatch, RecordBatchOptions},
+};
 use blaze_jni_bridge::{jni_call_static, jni_new_global_ref, jni_new_string};
 use datafusion::{
     common::{DataFusionError, Result, Statistics},
@@ -257,13 +260,18 @@ async fn execute_parquet_sink(
 }
 
 fn adapt_schema(batch: RecordBatch, schema: &SchemaRef) -> Result<RecordBatch> {
+    let num_rows = batch.num_rows();
     let casted_cols = batch
         .columns()
         .iter()
         .zip(&schema.fields)
         .map(|(col, to_field)| cast(col, to_field.data_type()))
         .collect::<Result<_>>()?;
-    Ok(RecordBatch::try_new(schema.clone(), casted_cols)?)
+    Ok(RecordBatch::try_new_with_options(
+        schema.clone(),
+        casted_cols,
+        &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+    )?)
 }
 
 fn parse_writer_props(prop_kvs: &[(String, String)]) -> WriterProperties {

--- a/native-engine/datafusion-ext-plans/src/sort_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/sort_exec.rs
@@ -971,10 +971,9 @@ mod fuzztest {
         common::{Result, ScalarValue},
         logical_expr::ColumnarValue,
         physical_expr::{expressions::Column, math_expressions::random, PhysicalSortExpr},
-        physical_plan::memory::MemoryExec,
+        physical_plan::{coalesce_batches::concat_batches, memory::MemoryExec},
         prelude::{SessionConfig, SessionContext},
     };
-    use datafusion_ext_commons::concat_batches;
 
     use crate::{memmgr::MemManager, sort_exec::SortExec};
 


### PR DESCRIPTION
in some cases where batch schema is empty, `RecordBatch::try_new` may returns error because number of rows is missing. this PR replace `try_new` with `try_new_with_options` in most situation.
`arrow::compute::concat_batches` is also updated in [7706029](https://github.com/blaze-init/arrow-rs/commit/7706029cfa5a130e0285bfe489c23f94c0d0635c).