### PR TITLE
fix shuffle data size counter

### DIFF
--- a/native-engine/datafusion-ext-commons/src/io/mod.rs
+++ b/native-engine/datafusion-ext-commons/src/io/mod.rs
@@ -30,7 +30,7 @@ pub fn write_one_batch<W: Write + Seek>(
     batch: &RecordBatch,
     output: &mut W,
     compress: bool,
-    uncompressed_size: Option<&mut usize>,
+    mut uncompressed_size: Option<&mut usize>,
 ) -> Result<usize> {
     if batch.num_rows() == 0 {
         return Ok(0);
@@ -38,6 +38,7 @@ pub fn write_one_batch<W: Write + Seek>(
     // write ipc_length placeholder
     let start_pos = output.stream_position()?;
     output.write_all(&[0u8; 8])?;
+    uncompressed_size.iter_mut().for_each(|v| **v += 8);
 
     // write
     batch_serde::write_batch(batch, output, compress, uncompressed_size)?;

--- a/native-engine/datafusion-ext-plans/src/shuffle/buffered_data.rs
+++ b/native-engine/datafusion-ext-plans/src/shuffle/buffered_data.rs
@@ -24,7 +24,7 @@ impl BufferedData {
         mut w: W,
         batch_size: usize,
         num_partitions: usize,
-        uncompressed_size: &mut usize,
+        num_bytes_written_uncompressed: &mut usize,
     ) -> common::Result<Vec<u64>> {
         let mut cur_partition_id = 0;
         let mut offsets = vec![0];
@@ -36,12 +36,14 @@ impl BufferedData {
                 cur_partition_id += 1;
             }
             let mut buf = vec![];
+            let mut uncompressed_size = 0;
             write_one_batch(
                 &batch,
                 &mut Cursor::new(&mut buf),
                 true,
-                Some(uncompressed_size),
+                Some(&mut uncompressed_size),
             )?;
+            *num_bytes_written_uncompressed += uncompressed_size;
             w.write_all(&buf)?;
             cur_offset += buf.len() as u64;
         }

--- a/spark-extension-shims-spark303/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeShuffleExchangeExec.scala
+++ b/spark-extension-shims-spark303/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeShuffleExchangeExec.scala
@@ -49,12 +49,13 @@ case class NativeShuffleExchangeExec(
     mutable.LinkedHashMap(
       NativeHelper
         .getDefaultNativeMetrics(sparkContext)
-        .filterKeys(Set(
-          "mem_spill_count",
-          "mem_spill_size",
-          "mem_spill_iotime",
-          "disk_spill_size",
-          "disk_spill_iotime"))
+        .filterKeys(
+          Set(
+            "mem_spill_count",
+            "mem_spill_size",
+            "mem_spill_iotime",
+            "disk_spill_size",
+            "disk_spill_iotime"))
         .toSeq: _*)).toMap
 
   lazy val readMetrics: Map[String, SQLMetric] =


### PR DESCRIPTION
# Which issue does this PR close?
currently the "data size" counter is incorrect, causing unexpected BHJ and failing some tpcds cases.
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
